### PR TITLE
fix: 翻译文章中的链接

### DIFF
--- a/JavaScript/typescript/use-typescript-two-years.md
+++ b/JavaScript/typescript/use-typescript-two-years.md
@@ -56,7 +56,7 @@
 
 TypeScript中有几种基本类型和一点点跟它们相关的高级类型和技术。
 
-下面你可以看到一些基础的但非常强大的东西，对于更高级的类型，请访问文档：https://www.typescriptlang.org/docs/handbook/advanced-types.html。
+下面你可以看到一些基础的但非常强大的东西，对于更高级的类型，请访问文档：<https://www.typescriptlang.org/docs/handbook/advanced-types.html>。
 
 ![](https://ecom.software/wp-content/uploads/2018/11/new-project7.png)
 


### PR DESCRIPTION
在 github 和 gitbook 中默认启用了`Autolinks (extension)`
在翻译的文章中,有一个链接后面跟着一个句号,这个句号会被`Autolinks (extension)`识别为链接的一部分,导致点击链接跳转到错误的 url,根据 [GFM#autolinks](https://github.github.com/gfm/#autolinks) 所述,可以用两个尖括号包裹链接,然后将句号放在右尖括号外,这样让自动链接生效的同时防止句号被识别为链接的一部分.